### PR TITLE
use the new logging level setter function of libusb when detected

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -249,7 +249,11 @@ int main(void)
     cbreak();
 
     r = libusb_init(NULL);
+#if LIBUSB_API_VERSION >= 0x01000106
+    libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+#else
     libusb_set_debug(NULL, LIBUSB_LOG_LEVEL_WARNING);       // LIBUSB_LOG_LEVEL_DEBUG  
+#endif
     if (r < 0)
     {
         printw("Unable to initialize libusb.\n");


### PR DESCRIPTION
Since version 1.0.22, libusb uses `libusb_set_option()` for setting logging level.

http://libusb.sourceforge.net/api-1.0/group__libusb__lib.html#gaf6ce5db28dac96b1680877a123da4fa8 